### PR TITLE
fix: remove logging.basicConfig() calls from library modules (issue #3)

### DIFF
--- a/src/ccda_to_omop/__init__.py
+++ b/src/ccda_to_omop/__init__.py
@@ -12,14 +12,11 @@ if sys.version_info < MIN_PYTHON:
     sys.exit(f"Python version {MIN_PYTHON}  or later is required.")
 
 
-logging.basicConfig(
-    stream=sys.stdout,
-    format='%(levelname)s: %(message)s',
-    # level=logging.ERROR
-    level=logging.WARNING
-    # level=logging.INFO
-    # level=logging.DEBUG
-)
+# Library code should not configure logging. Per Python logging best practices,
+# we attach a NullHandler so that log records are discarded unless the
+# application configures a handler. Applications should call
+# logging.basicConfig() (or equivalent) before using this package.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # NOTE: The global dictionaries and their setters/getters
 # have been moved to value_transformations.py

--- a/src/ccda_to_omop/ddl.py
+++ b/src/ccda_to_omop/ddl.py
@@ -23,13 +23,6 @@ import importlib.util
 from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format='%(levelname)s: %(message)s',
-#    filename=f"logs/load_omop.log",
-#    force=True,
-    level=logging.INFO
-    # level=logging.WARNING level=logging.ERROR # level=logging.INFO # level=logging.DEBUG
-)
 
 
 

--- a/src/ccda_to_omop/layer_datasets.py
+++ b/src/ccda_to_omop/layer_datasets.py
@@ -56,14 +56,7 @@ warnings.simplefilter(action='ignore', category=FutureWarning) #*
 #*                                                              * 
 #****************************************************************a
 
-logging.basicConfig(
-        filename="layer_datasets.log",
-        filemode="w",
-        level=logging.INFO ,
-        format='%(levelname)s:%(filename)s:%(funcName)s:%(lineno)d %(message)s' )
-
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.ERROR)
 
 @typechecked
 def show_column_dict(config_name, column_dict):

--- a/src/ccda_to_omop/load_duck_db.py
+++ b/src/ccda_to_omop/load_duck_db.py
@@ -43,13 +43,6 @@ from typing import Dict, Any
 #from .ddl import  device_ddl
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format='%(levelname)s: %(message)s',
-#    filename=f"logs/load_omop.log",
-#    force=True,
-    level=logging.INFO
-    # level=logging.WARNING level=logging.ERROR # level=logging.INFO # level=logging.DEBUG
-)
 
 processing_status = True
 

--- a/src/ccda_to_omop/util.py
+++ b/src/ccda_to_omop/util.py
@@ -6,14 +6,7 @@ from dateutil.parser import parse
 import csv
 import datetime
 
-logging.basicConfig(
-        filename="layer_datasets.log",
-        filemode="w",
-        level=logging.INFO ,
-        format='%(levelname)s:%(filename)s:%(funcName)s:%(lineno)d %(message)s')
-
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.ERROR)
 """
     These three functions create dictionaries from the vocabulary xwalk 
     pandas dataframes.

--- a/src/ccda_to_omop/value_transformations.py
+++ b/src/ccda_to_omop/value_transformations.py
@@ -7,12 +7,6 @@ from ccda_to_omop.util import cast_to_datetime
 from ccda_to_omop import package_constant_access
 import logging
 
-logging.basicConfig(
-        filename="layer_datasets.log",
-        filemode="w",
-        level=logging.INFO ,
-        format='%(levelname)s:%(filename)s:%(funcName)s:%(lineno)d %(message)s')
-        
 """
     Functions for use in DERVIED fields.
     The configuration for this type of field is:
@@ -32,7 +26,6 @@ logging.basicConfig(
 """    
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.ERROR)
 
 # --- Start of Moved Code from __init__.py ---
 # These dictionaries are now defined and handled here.


### PR DESCRIPTION
## Summary
- Removes all six `logging.basicConfig()` calls from library modules (`__init__.py`, `util.py`, `value_transformations.py`, `ddl.py`, `load_duck_db.py`, `layer_datasets.py`)
- Replaces each with `logging.getLogger(__name__)` so each module uses a properly namespaced logger
- Adds `logging.NullHandler()` in `__init__.py` per Python logging best practices for libraries, so log records are silently discarded unless the calling application configures its own handler

Fixes #3

## Test plan
- [ ] Run existing test suite to confirm no regressions
- [ ] Verify that log output is still visible when an application configures `logging.basicConfig()` before importing the package
- [ ] Verify that no log output appears when the application does not configure logging (NullHandler behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)