### PR TITLE
fix: set attribute_value=None and narrow exception types on failed casts (issue #5)

### DIFF
--- a/src/ccda_to_omop/data_driven_parse.py
+++ b/src/ccda_to_omop/data_driven_parse.py
@@ -220,32 +220,37 @@ def parse_field_from_dict(field_details_dict :dict[str, str], root_element,
             elif field_details_dict['data_type'] == 'LONG':
                 try:
                     attribute_value = int64(attribute_value)
-                except Exception as e:
-                    logger.warning(f"cast to int64 failed for config:{config_name} field:{field_tag} val:{attribute_value}") 
+                except (ValueError, TypeError, OverflowError) as e:
+                    logger.warning(f"cast to int64 failed for config:{config_name} field:{field_tag} val:{attribute_value} exception:{e}")
+                    attribute_value = None
 
             elif field_details_dict['data_type'] == 'INTEGER':
                 try:
                     attribute_value = int32(attribute_value)
-                except Exception as e:
-                    logger.warning(f"cast to int32 failed for config:{config_name} field:{field_tag} val:{attribute_value}") 
+                except (ValueError, TypeError, OverflowError) as e:
+                    logger.warning(f"cast to int32 failed for config:{config_name} field:{field_tag} val:{attribute_value} exception:{e}")
+                    attribute_value = None
 
             elif field_details_dict['data_type'] == 'BIGINTHASH':
                 try:
                     attribute_value = create_hash(attribute_value)
-                except Exception as e:
-                    logger.warning(f"cast to hash failed for config:{config_name} field:{field_tag} val:{attribute_value}") 
+                except (TypeError, ValueError) as e:
+                    logger.warning(f"cast to hash failed for config:{config_name} field:{field_tag} val:{attribute_value} exception:{e}")
+                    attribute_value = None
 
             elif field_details_dict['data_type'] == 'TEXT':
                 try:
                     attribute_value = str(attribute_value)
-                except Exception as e:
-                    logger.warning(f"cast to hash failed for config:{config_name} field:{field_tag} val:{attribute_value}") 
+                except (TypeError, ValueError) as e:
+                    logger.warning(f"cast to str failed for config:{config_name} field:{field_tag} val:{attribute_value} exception:{e}")
+                    attribute_value = None
 
             elif field_details_dict['data_type'] == 'FLOAT':
                 try:
                     attribute_value = float(attribute_value)
-                except Exception as e:
-                    logger.warning(f"cast to float failed for config:{config_name} field:{field_tag} val:{attribute_value}") 
+                except (ValueError, TypeError, OverflowError) as e:
+                    logger.warning(f"cast to float failed for config:{config_name} field:{field_tag} val:{attribute_value} exception:{e}")
+                    attribute_value = None
                     
             else:
                 logger.warning(f" UNKNOWN DATA TYPE: {field_details_dict['data_type']} {config_name} {field_tag}")

--- a/src/ccda_to_omop/layer_datasets.py
+++ b/src/ccda_to_omop/layer_datasets.py
@@ -224,14 +224,10 @@ def create_omop_domain_dataframes(omop_data: dict[str, list[ dict[str,  None | s
                                        f"rows with missing required fields (table={table_name})")
 
                 df_dict[config_name] = domain_df
-            except ValueError as ve:
-                logger.info(f"when creating dataframe for {config_name} in {filepath} HAVE DATA {df_dict}")
+            except (ValueError, KeyError) as e:
+                logger.error(f"failed to create dataframe for {config_name} in {filepath}: {e}")
                 show_column_dict(config_name, column_dict)
                 df_dict[config_name] = None
-            # except Exception as x:
-                # logger.error(f"exception {config_name} in {filepath} NO DATA RETURNED {x}")
-                # show_column_dict(config_name, column_dict)
-                # df_dict[config_name] = None
             logger.error(f"(create_omop_domain_dataframes) No data to create dataframe for {config_name} from {filepath} {domain_list}")
     return df_dict
 


### PR DESCRIPTION
## Summary
Fixes the HIGH severity bare-except handlers identified in issue #5.

**`data_driven_parse.py`** — five type-casting blocks (LONG, INTEGER, BIGINTHASH, TEXT, FLOAT) all caught bare `Exception` but never set `attribute_value = None` on failure, leaving the unconverted value in the field and corrupting downstream output. Each block now:
- catches only the exceptions that conversion can actually raise (`ValueError`, `TypeError`, `OverflowError` as appropriate)
- sets `attribute_value = None` on failure so the field is explicitly absent rather than holding the wrong type
- includes the exception message in the warning log

**`layer_datasets.py`** — the DataFrame creation `try/except` only caught `ValueError`, silently missing `KeyError` from `config_to_domain_name_dict` and `domain_name_to_table_name` lookups (lines 171–172). Now catches `(ValueError, KeyError)`, log level raised to `error`, and the dead commented-out fallback block is removed.

The MODERATE-severity handlers in both files are left for a follow-up PR.

Fixes #5 (high-severity handlers only)

## Test plan
- [ ] Existing unit test suite passes (CI)
- [ ] Confirm that a field with an unparseable integer value now results in `None` in the output record rather than the original string

🤖 Generated with [Claude Code](https://claude.com/claude-code)