### PR TITLE
Add map.csv download to file comparisons workflow

### DIFF
--- a/.github/workflows/file_comparisons.yml
+++ b/.github/workflows/file_comparisons.yml
@@ -12,6 +12,12 @@ jobs:
           - name: Install packages
             run: |
                 pip install -r requirements.txt
+          - name: get the concept map file
+            run: |
+              wget --header="Authorization: token ${{ secrets.CROEDER_CCDA_PRIVATE_ACCESS_TOKEN }}" \
+                   --header="Accept: */*" \
+                   -O resources/map.csv \
+                   "https://raw.githubusercontent.com/croeder/CCDA_OMOP_Private/main/map.csv"
           - name: run conversion
             run: |
                 bin/process.sh


### PR DESCRIPTION
## Summary
- File comparisons workflow was missing the map.csv fetch step, causing the conversion to fail
- Added wget step matching the pattern used in unittests.yml and coverage.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)