### PR TITLE
Fix JSON escaping in badge gist update

### DIFF
--- a/.github/workflows/file_comparisons.yml
+++ b/.github/workflows/file_comparisons.yml
@@ -47,7 +47,10 @@ jobs:
                 errors=${{ steps.compare.outputs.errors }}
                 [ "$errors" -eq 0 ] && color="brightgreen" || color="red"
                 message="${matching}/${total} matching"
-                payload=$(printf '{"files":{"comparison-badge.json":{"content":"{\"schemaVersion\":1,\"label\":\"file comparisons\",\"message\":\"%s\",\"color\":\"%s\"}"}}}' "$message" "$color")
+                payload=$(python3 -c "
+import json
+content = json.dumps({'schemaVersion': 1, 'label': 'file comparisons', 'message': '$message', 'color': '$color'})
+print(json.dumps({'files': {'comparison-badge.json': {'content': content}}}))")
                 curl -s -X PATCH \
                   -H "Authorization: token $GIST_TOKEN" \
                   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- The \`printf\`-built JSON payload was rejected by the GitHub Gist API with \"Problems parsing JSON\"
- Replaced with Python \`json.dumps\` to correctly escape the nested JSON content string

🤖 Generated with [Claude Code](https://claude.com/claude-code)