### PR TITLE
Use jq to build gist badge payload

### DIFF
--- a/.github/workflows/file_comparisons.yml
+++ b/.github/workflows/file_comparisons.yml
@@ -47,10 +47,10 @@ jobs:
                 errors=${{ steps.compare.outputs.errors }}
                 [ "$errors" -eq 0 ] && color="brightgreen" || color="red"
                 message="${matching}/${total} matching"
-                payload=$(python3 -c "
-import json
-content = json.dumps({'schemaVersion': 1, 'label': 'file comparisons', 'message': '$message', 'color': '$color'})
-print(json.dumps({'files': {'comparison-badge.json': {'content': content}}}))")
+                payload=$(jq -n \
+                  --arg msg "$message" \
+                  --arg color "$color" \
+                  '{files: {"comparison-badge.json": {content: ({schemaVersion: 1, label: "file comparisons", message: $msg, color: $color} | tojson)}}}')
                 curl -s -X PATCH \
                   -H "Authorization: token $GIST_TOKEN" \
                   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- Python dict literals containing \`}}\` sequences were tripping the GitHub Actions expression parser, causing an immediate workflow file error
- Replaced with \`jq\` which is always available on ubuntu runners and handles the nested JSON cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)