### PR TITLE
Switch workflow map.csv URL back to croeder/CCDA_OMOP_Private

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
               wget --header="Authorization: token ${{ secrets.CROEDER_CCDA_PRIVATE_ACCESS_TOKEN }}" \
                    --header="Accept: */*" \
                    -O resources/map.csv \
-                   "https://raw.githubusercontent.com/chrisroederucdenver/CCDA_OMOP_Private/main/map.csv"
+                   "https://raw.githubusercontent.com/croeder/CCDA_OMOP_Private/main/map.csv"
           - name: Run tests with coverage
             run: |
                 cd src

--- a/.github/workflows/file_comparisons.yml
+++ b/.github/workflows/file_comparisons.yml
@@ -17,7 +17,7 @@ jobs:
               wget --header="Authorization: token ${{ secrets.CROEDER_CCDA_PRIVATE_ACCESS_TOKEN }}" \
                    --header="Accept: */*" \
                    -O resources/map.csv \
-                   "https://raw.githubusercontent.com/chrisroederucdenver/CCDA_OMOP_Private/main/map.csv"
+                   "https://raw.githubusercontent.com/croeder/CCDA_OMOP_Private/main/map.csv"
           - name: run conversion
             run: |
                 bin/process.sh || true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -18,6 +18,6 @@ jobs:
               wget --header="Authorization: token ${{ secrets.CROEDER_CCDA_PRIVATE_ACCESS_TOKEN }}" \
                    --header="Accept: */*" \
                    -O resources/map.csv \
-                   "https://raw.githubusercontent.com/chrisroederucdenver/CCDA_OMOP_Private/main/map.csv"
+                   "https://raw.githubusercontent.com/croeder/CCDA_OMOP_Private/main/map.csv"
           - name: run unit tests
             run: bin/run_unittests.sh


### PR DESCRIPTION
## Summary
- `chrisroederucdenver/CCDA_OMOP_Private` was not accessible from GitHub Actions
- Fixed root cause in `CCDA_OMOP_Private` repo: `.gitattributes` had `###` accidentally commenting out the `map.csv` LFS exclusion rule, causing `map.csv` to be stored as an LFS object (which `raw.githubusercontent.com` serves as a pointer, not content)
- Restored the exclusion, merged to `main`, pushed to `croeder/CCDA_OMOP_Private`
- Updated all three workflow files to use `croeder/CCDA_OMOP_Private`

## Test plan
- [ ] Trigger `unittests.yml` workflow and verify the `get the concept map file` step succeeds
- [ ] Verify `coverage.yml` and `file_comparisons.yml` also fetch map.csv successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)