### PR TITLE
Add Sphinx docs with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Build and deploy docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx-rtd-theme
+          pip install -r requirements.txt
+
+      - name: Regenerate API stubs
+        run: |
+          sphinx-apidoc \
+            --force \
+            --module-first \
+            --separate \
+            -o docs/api \
+            src/ccda_to_omop \
+            src/ccda_to_omop/metadata
+
+      - name: Build HTML
+        run: sphinx-build -b html docs docs/_build/html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/bin/build_docs.sh
+++ b/bin/build_docs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env zsh
+# Regenerate API docs and rebuild HTML.
+# Run after major code changes (new modules, significant docstring updates).
+#
+# Requires: pip install sphinx sphinx-rtd-theme
+#
+# Usage: bin/build_docs.sh [--open]
+
+set -e
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SRC="$REPO_ROOT/src/ccda_to_omop"
+DOCS="$REPO_ROOT/docs"
+
+cd "$REPO_ROOT"
+
+echo "==> Regenerating API stubs from source..."
+sphinx-apidoc \
+    --force \
+    --module-first \
+    --separate \
+    -o "$DOCS/api" \
+    "$SRC" \
+    "$SRC/metadata"   # exclude: hyphenated filenames break autodoc
+
+echo "==> Building HTML..."
+sphinx-build -b html "$DOCS" "$DOCS/_build/html"
+
+echo ""
+echo "Done. Docs at: $DOCS/_build/html/index.html"
+
+if [[ "$1" == "--open" ]]; then
+    open "$DOCS/_build/html/index.html"
+fi

--- a/docs/api/ccda_to_omop.code_hunt.rst
+++ b/docs/api/ccda_to_omop.code_hunt.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.code\_hunt module
+================================
+
+.. automodule:: ccda_to_omop.code_hunt
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.constants.rst
+++ b/docs/api/ccda_to_omop.constants.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.constants module
+===============================
+
+.. automodule:: ccda_to_omop.constants
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.data_driven_parse.rst
+++ b/docs/api/ccda_to_omop.data_driven_parse.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.data\_driven\_parse module
+=========================================
+
+.. automodule:: ccda_to_omop.data_driven_parse
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.ddl.rst
+++ b/docs/api/ccda_to_omop.ddl.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.ddl module
+=========================
+
+.. automodule:: ccda_to_omop.ddl
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.domain_dataframe_column_types.rst
+++ b/docs/api/ccda_to_omop.domain_dataframe_column_types.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.domain\_dataframe\_column\_types module
+======================================================
+
+.. automodule:: ccda_to_omop.domain_dataframe_column_types
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.find_paths.rst
+++ b/docs/api/ccda_to_omop.find_paths.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.find\_paths module
+=================================
+
+.. automodule:: ccda_to_omop.find_paths
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.layer_datasets.rst
+++ b/docs/api/ccda_to_omop.layer_datasets.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.layer\_datasets module
+=====================================
+
+.. automodule:: ccda_to_omop.layer_datasets
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.load_duck_db.rst
+++ b/docs/api/ccda_to_omop.load_duck_db.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.load\_duck\_db module
+====================================
+
+.. automodule:: ccda_to_omop.load_duck_db
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.package_constant_access.rst
+++ b/docs/api/ccda_to_omop.package_constant_access.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.package\_constant\_access module
+===============================================
+
+.. automodule:: ccda_to_omop.package_constant_access
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.rst
+++ b/docs/api/ccda_to_omop.rst
@@ -1,0 +1,26 @@
+ccda\_to\_omop package
+======================
+
+.. automodule:: ccda_to_omop
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   ccda_to_omop.code_hunt
+   ccda_to_omop.constants
+   ccda_to_omop.data_driven_parse
+   ccda_to_omop.ddl
+   ccda_to_omop.domain_dataframe_column_types
+   ccda_to_omop.find_paths
+   ccda_to_omop.layer_datasets
+   ccda_to_omop.load_duck_db
+   ccda_to_omop.package_constant_access
+   ccda_to_omop.util
+   ccda_to_omop.value_transformations
+   ccda_to_omop.visit_reconciliation

--- a/docs/api/ccda_to_omop.util.rst
+++ b/docs/api/ccda_to_omop.util.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.util module
+==========================
+
+.. automodule:: ccda_to_omop.util
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.value_transformations.rst
+++ b/docs/api/ccda_to_omop.value_transformations.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.value\_transformations module
+============================================
+
+.. automodule:: ccda_to_omop.value_transformations
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/ccda_to_omop.visit_reconciliation.rst
+++ b/docs/api/ccda_to_omop.visit_reconciliation.rst
@@ -1,0 +1,7 @@
+ccda\_to\_omop.visit\_reconciliation module
+===========================================
+
+.. automodule:: ccda_to_omop.visit_reconciliation
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,7 @@
+ccda_to_omop
+============
+
+.. toctree::
+   :maxdepth: 4
+
+   ccda_to_omop

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../src'))
+
+project = 'ccda_to_omop'
+copyright = '2024, Chris Roeder'
+author = 'Chris Roeder'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'pandas': ('https://pandas.pydata.org/docs/', None),
+}
+
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+}
+
+templates_path = ['_templates']
+exclude_patterns = ['_build']
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,12 @@
+ccda_to_omop
+============
+
+Converts `C-CDA <https://www.hl7.org/ccdasearch/>`_ XML documents into
+`OMOP CDM <https://ohdsi.github.io/CommonDataModel/>`_ tabular records.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   overview
+   api/modules

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,0 +1,43 @@
+Overview
+========
+
+``ccda_to_omop`` converts HL7 C-CDA (Consolidated Clinical Document
+Architecture) XML documents into OMOP CDM tabular records.
+
+Architecture
+------------
+
+The conversion is driven by a metadata configuration layer. Each OMOP domain
+(e.g. ``condition_occurrence``, ``drug_exposure``, ``observation``) has a
+corresponding metadata file that describes which C-CDA XPaths map to which
+OMOP columns. Adding a new domain requires only a new metadata config — no
+changes to the core parsing engine.
+
+Key modules
+-----------
+
+- **data_driven_parse** — XPath-based C-CDA XML parser driven by metadata configs
+- **layer_datasets** — orchestrates per-file, per-config parsing into pandas DataFrames
+- **value_transformations** — concept code mapping and value normalization
+- **visit_reconciliation** — links clinical events to visit_occurrence records
+- **ddl** — OMOP table definitions and domain→table name mappings
+- **domain_dataframe_column_types** — pandas dtype specifications per OMOP table
+- **util** — shared helpers (codemap loading, etc.)
+
+Installation
+------------
+
+.. code-block:: bash
+
+    git clone https://github.com/croeder/CCDA_OMOP_Conversion_Package.git
+    cd CCDA_OMOP_Conversion_Package
+    python -m venv env
+    source env/bin/activate
+    pip install -r requirements.txt
+
+Usage
+-----
+
+.. code-block:: bash
+
+    bin/process.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling >= 1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ccda_to_omop"
+version = "2.0.2"
+authors = [ { name="Chris Roeder", email="croeder@croeder.com" }, ]
+description = "An HL7 C-CDA to OMOP Converter"
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = "GPL-3.0"
+license-files = ["LICEN[CS]E*"]
+
+[project.optional-dependencies]
+docs = [
+    "sphinx>=7.0",
+    "sphinx-rtd-theme>=2.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/croeder/CCDA_OMOP_Conversion_Package"
+Issues = "https://github.com/croeder/CCDA_OMOP_Conversion_Package/issues"
+Documentation = "https://croeder.github.io/CCDA_OMOP_Conversion_Package/"


### PR DESCRIPTION
## Summary

- `docs/conf.py`: Sphinx config with autodoc, napoleon, rtd-theme; handles `src/` layout
- `docs/index.rst` + `docs/overview.rst`: top-level and architecture narrative pages
- `docs/api/`: per-module `.rst` stubs generated by `sphinx-apidoc` (metadata/ dir excluded — hyphenated filenames can't be imported)
- `.github/workflows/docs.yml`: builds HTML and deploys to `gh-pages` branch on every push to master that touches `src/` or `docs/`
- `bin/build_docs.sh`: local script to regenerate stubs + rebuild HTML after major code changes (`bin/build_docs.sh --open`)
- `pyproject.toml`: added `[project.optional-dependencies] docs = [sphinx, sphinx-rtd-theme]` and Documentation URL

## After merge — one-time GitHub setup

Enable GitHub Pages in repo **Settings → Pages**:
- Source: **Deploy from a branch**
- Branch: `gh-pages` / `/ (root)`

The docs will then be live at: https://croeder.github.io/CCDA_OMOP_Conversion_Package/

## Test plan

- [x] Local build: `bin/build_docs.sh` completes with no errors (37 warnings = missing docstrings, not errors)
- [ ] After merge: confirm Actions workflow triggers and `gh-pages` branch is created
- [ ] Enable GitHub Pages in repo settings and verify URL is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)