### PR TITLE
Skip TEMPLATE.py in metadata discovery to fix linter test

### DIFF
--- a/src/ccda_to_omop/metadata/__init__.py
+++ b/src/ccda_to_omop/metadata/__init__.py
@@ -89,6 +89,7 @@ def discover_and_sort_metadata() -> Dict[str, Any]:
         return {}
 
     files_to_skip = ['__init__.py', 'test.py', 'ddl.py', 'util.py',
+        'TEMPLATE.py',  # annotated skeleton for new configs — not a real config
         'test'  # (though a dir, still needs to be skipped, getting an error about test.py?
     ]
     filenames = os.listdir(METADATA_DIR)


### PR DESCRIPTION
## Summary

`TEMPLATE.py` (added in #110) was being picked up by `metadata/__init__.py`'s auto-discovery and loaded as a real parse config. The linter test then failed because it uses placeholder `my_*` field names instead of actual OMOP column names for its declared `expected_domain_id: Condition`.

Fix: add `TEMPLATE.py` to the `files_to_skip` list in `metadata/__init__.py`, alongside `__init__.py` and other non-config files.

## Test plan
- [x] `pytest src/tests/test_linter.py` — 51 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)