### PR TITLE
docs: add PyPI version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This is a project to convert CCDA documents to OMOP CDM format in Python.
 
 [![codecov](https://codecov.io/gh/croeder/CCDA_OMOP_Conversion_Package/graph/badge.svg)](https://codecov.io/gh/croeder/CCDA_OMOP_Conversion_Package)
 
+[![PyPI version](https://img.shields.io/pypi/v/ccda_to_omop.svg)](https://pypi.org/project/ccda_to_omop/)
+
 [Documentation](https://croeder.github.io/CCDA_OMOP_Conversion_Package/)
 
 ## What it does


### PR DESCRIPTION
## Summary

- Adds a PyPI version badge to README.md linking to https://pypi.org/project/ccda_to_omop/
- Badge shows the current published version (currently 2.0.4) and updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)